### PR TITLE
Feature/#49 mojolicious deprecated api

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for {{$dist->name}}
 
 {{$NEXT}}
+    - Mojo::Home의 사라진 API를 사용함 (#49)
     - 푸터의 온라인 예약 링크 주소를 변경함 (#48)
 
 0.006     2017-01-20 11:23:53+09:00 Asia/Seoul

--- a/lib/OpenCloset/Story/Web.pm
+++ b/lib/OpenCloset/Story/Web.pm
@@ -319,7 +319,7 @@ sub _load_config {
 sub _to_abs {
     my ( $self, $dir ) = @_;
 
-    $dir = $self->home->rel_dir($dir) unless $dir =~ m{^/};
+    $dir = $self->home->rel_file($dir)->to_abs->to_string unless $dir =~ m{^/};
 
     return $dir;
 }

--- a/lib/OpenCloset/Story/Web.pm
+++ b/lib/OpenCloset/Story/Web.pm
@@ -332,7 +332,7 @@ sub startup {
     my $app = shift;
 
     # set home folder
-    $app->home->parse( $app->home_path );
+    $app->home( $app->home->new( $app->home_path ) );
 
     {
         # setup logging path


### PR DESCRIPTION
Mojolicious 7.15 버전 부터 Mojo::Home 모듈에서 사라진 `parse`, `rel_dir` 메소드를 사용하지 않도록 수정합니다.